### PR TITLE
chore(deps): bump  versions

### DIFF
--- a/charts/cloudbees/jx-tenant-service.yml
+++ b/charts/cloudbees/jx-tenant-service.yml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/cloudbees/jx-tenant-service
-version: 0.0.129
+version: 0.0.134

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -58,3 +58,4 @@ Dependency | Sources | Version | Mismatched versions
 [heptio/velero](https://github.com/heptio/velero):velero |  | [2.3.0]() | 
 [jenkins-x/jenkins-x-builders-base](https://github.com/jenkins-x/jenkins-x-builders-base) | [github.com/jenkins-x/jenkins-x-builders-ml](https://github.com/jenkins-x/jenkins-x-builders-ml.git) | [0.0.68](https://github.com/jenkins-x/jenkins-x-builders-base/releases/tag/v0.0.68) | 
 [cloudbees/arcalos-boot-config](https://github.com/cloudbees/arcalos-boot-config) |  | [1.0.19](https://github.com/cloudbees/arcalos-boot-config/releases/tag/v1.0.19) | 
+[cloudbees/jx-tenant-service](https://github.com/cloudbees/jx-tenant-service) |  | [0.0.134](https://github.com/cloudbees/jx-tenant-service/releases/tag/v0.0.134) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -398,3 +398,9 @@ dependencies:
   url: https://github.com/cloudbees/arcalos-boot-config
   version: 1.0.19
   versionURL: https://github.com/cloudbees/arcalos-boot-config/releases/tag/v1.0.19
+- host: github.com
+  owner: cloudbees
+  repo: jx-tenant-service
+  url: https://github.com/cloudbees/jx-tenant-service
+  version: 0.0.134
+  versionURL: https://github.com/cloudbees/jx-tenant-service/releases/tag/v0.0.134


### PR DESCRIPTION
Update  versions

Command run was `jx step create pr versions -n cloudbees/jx-tenant-service -k charts -v 0.0.134 --repo https://github.com/cloudbees/arcalos-jenkins-x-versions.git`