### PR TITLE
chore(deps): bump https://github.com/cloudbees/jx-tenant-service from 0.0.129, 0.0.211 to 0.0.211

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -57,8 +57,8 @@ Dependency | Sources | Version | Mismatched versions
 [jenkins-x-quickstarts/vertx-rest-prometheus](https://github.com/jenkins-x-quickstarts/vertx-rest-prometheus.git) |  | [1.0.0+fd180fd76]() | 
 [heptio/velero](https://github.com/heptio/velero):velero |  | [2.3.1]() | 
 [jenkins-x/jenkins-x-builders-base](https://github.com/jenkins-x/jenkins-x-builders-base) | [github.com/jenkins-x/jenkins-x-builders-ml](https://github.com/jenkins-x/jenkins-x-builders-ml.git) | [0.0.68](https://github.com/jenkins-x/jenkins-x-builders-base/releases/tag/v0.0.68) | 
-[cloudbees/arcalos-boot-config](https://github.com/cloudbees/arcalos-boot-config) |  | [1.0.42](https://github.com/cloudbees/arcalos-boot-config/releases/tag/v1.0.42) | 
-[cloudbees/jx-tenant-service](https://github.com/cloudbees/jx-tenant-service) | [github.com/cloudbees/arcalos-boot-config](https://github.com/cloudbees/arcalos-boot-config) | [0.0.211](https://github.com/cloudbees/jx-tenant-service/releases/tag/v0.0.211) | **0.0.208**: [github.com/cloudbees/arcalos-boot-config](https://github.com/cloudbees/arcalos-boot-config)
+[cloudbees/arcalos-boot-config](https://github.com/cloudbees/arcalos-boot-config) |  | [1.0.48](https://github.com/cloudbees/arcalos-boot-config/releases/tag/v1.0.48) | 
+[cloudbees/jx-tenant-service](https://github.com/cloudbees/jx-tenant-service) | [github.com/cloudbees/arcalos-boot-config](https://github.com/cloudbees/arcalos-boot-config) | [0.0.211](https://github.com/cloudbees/jx-tenant-service/releases/tag/v0.0.211) | **0.0.210**: [github.com/cloudbees/arcalos-boot-config](https://github.com/cloudbees/arcalos-boot-config)
 [helm/cert-manager](https://github.com/helm/charts/tree/master/stable/cert-manager):cert-manager |  | [0.6.7]() | 
 [bitnami/external-dns](https://github.com/bitnami/charts/tree/master/bitnami/external-dns) |  | [2.10.0]() | 
 [helm/nginx-ingress](https://github.com/helm/charts/tree/master/stable/nginx-ingress):nginx-ingress |  | [1.24.5]() | 

--- a/docker/gcr.io/jenkinsxio/jx-tenant-service.yml
+++ b/docker/gcr.io/jenkinsxio/jx-tenant-service.yml
@@ -1,1 +1,1 @@
-version: 0.0.129
+version: 0.0.211


### PR DESCRIPTION
Update [cloudbees/jx-tenant-service](https://github.com/cloudbees/jx-tenant-service) from 0.0.129, 0.0.211 to [0.0.211](https://github.com/cloudbees/jx-tenant-service/releases/tag/v0.0.211)

Command run was `jx step create pr regex --regex (?m)^version: (?P<version>.*)$ --version 0.0.211 --files docker/gcr.io/jenkinsxio/jx-tenant-service.yml --files charts/cloudbees/jx-tenant-service.yml --repo https://github.com/cloudbees/arcalos-jenkins-x-versions.git`